### PR TITLE
Bump poi-scratchpad from 3.9 to 5.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
 		<dependency>
 			<groupId>org.apache.poi</groupId>
 			<artifactId>poi-scratchpad</artifactId>
-			<version>3.9</version>
+			<version>5.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>


### PR DESCRIPTION
Bumps poi-scratchpad from 3.9 to 5.2.1.

---
updated-dependencies:
- dependency-name: org.apache.poi:poi-scratchpad dependency-type: direct:production ...